### PR TITLE
fix: open STIG files with explicit UTF-8 encoding

### DIFF
--- a/stigaview_static/import_stig.py
+++ b/stigaview_static/import_stig.py
@@ -115,6 +115,6 @@ def _get_stig_version(stig_path):
 
 
 def _get_root_from_xml_path(stig_path) -> ET.ElementTree:
-    with open(stig_path) as stig_file:
+    with open(stig_path, encoding="utf-8") as stig_file:
         root = ET.ElementTree(ET.fromstring(stig_file.read()))
     return root


### PR DESCRIPTION
Ensure all files are opened with UTF-8 instead of relying on OS defaults. This prevents UnicodeDecodeError on Windows and ensures consistent behavior across environments when parsing STIG data containing special characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures XML imports use UTF-8 encoding, preventing parsing errors and garbled characters for non-ASCII content.
  * Improves consistency across platforms by standardizing file reading behavior, reducing sporadic import failures.
  * Users working with legacy-encoded XML may need to convert files to UTF-8 to import successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->